### PR TITLE
feat: アイコンライブラリをlucide-reactからreact-iconsに変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.511.0",
         "monaco-editor": "^0.52.2",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
@@ -4226,14 +4226,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lucide-react": {
-      "version": "0.511.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
-      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -4888,6 +4880,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.511.0",
     "monaco-editor": "^0.52.2",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -11,10 +11,10 @@ import { ToastContainer } from '@/components/toast/ToastContainer';
 import { useGoExecutor } from '@/hooks/useGoExecutor';
 import { useLessons } from '@/hooks/useLessons';
 import { useToast } from '@/hooks/useToast';
-import { ArrowLeft } from 'lucide-react';
+import { IoArrowBack } from 'react-icons/io5';
 import { validateLesson } from '@/lib/validation';
 import { ValidationResult } from '@/types/lesson';
-import { getLessonTheme, CategoryTheme } from '@/lib/theme';
+import { getLessonTheme } from '@/lib/theme';
 
 interface LessonPageProps {
   params: Promise<{
@@ -34,7 +34,6 @@ export default function LessonPage({ params }: LessonPageProps) {
     currentLesson,
     isLoading,
     error,
-    loadLessons,
     selectLesson,
     updateProgress,
     getNextLesson,
@@ -154,7 +153,7 @@ export default function LessonPage({ params }: LessonPageProps) {
           onClick={handleBackToList}
           className="flex items-center gap-2 px-4 py-2 text-blue-600 hover:text-blue-700"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <IoArrowBack className="w-4 h-4" />
           レッスン一覧に戻る
         </button>
       </div>
@@ -174,7 +173,7 @@ export default function LessonPage({ params }: LessonPageProps) {
           onClick={handleBackToList}
           className={`flex items-center gap-2 ${theme.textColor} hover:opacity-80 transition-colors`}
         >
-          <ArrowLeft className="w-4 h-4" />
+          <IoArrowBack className="w-4 h-4" />
           レッスン一覧
         </button>
       </div>

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -3,16 +3,12 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useLessons } from '@/hooks/useLessons';
-import { Category, Lesson } from '@/types/lesson';
-import { ChevronRight, CheckCircle, Clock, Play } from 'lucide-react';
+import { Lesson } from '@/types/lesson';
+import { IoChevronForward, IoCheckmarkCircle, IoTime, IoPlay } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 import { 
   getCategoryTheme, 
-  getCategoryCardClasses, 
-  getCategoryTextClasses,
-  getCategoryAccentClasses,
   getDifficultyBadgeClasses,
-  getProgressBarClasses,
   CategoryTheme
 } from '@/lib/theme';
 
@@ -70,27 +66,6 @@ export default function LessonsPage() {
     return Math.round((completed / categoryLessons.length) * 100);
   };
 
-  const getDifficultyColor = (difficulty: Lesson['difficulty']) => {
-    switch (difficulty) {
-      case 'beginner':
-        return 'text-green-600 bg-green-50';
-      case 'intermediate':
-        return 'text-yellow-600 bg-yellow-50';
-      case 'advanced':
-        return 'text-red-600 bg-red-50';
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'completed':
-        return <CheckCircle className="w-5 h-5 text-green-600" />;
-      case 'in-progress':
-        return <Clock className="w-5 h-5 text-yellow-600" />;
-      default:
-        return <Play className="w-5 h-5 text-gray-400" />;
-    }
-  };
 
   if (isLoading) {
     return (
@@ -251,11 +226,11 @@ function LessonCard({ lesson, status, onClick }: LessonCardProps) {
     const iconClass = "w-5 h-5";
     switch (status) {
       case 'completed':
-        return <CheckCircle className={cn(iconClass, "text-green-600")} />;
+        return <IoCheckmarkCircle className={cn(iconClass, "text-green-600")} />;
       case 'in-progress':
-        return <Clock className={cn(iconClass, "text-yellow-600")} />;
+        return <IoTime className={cn(iconClass, "text-yellow-600")} />;
       default:
-        return <Play className={cn(iconClass, theme.accentColor)} />;
+        return <IoPlay className={cn(iconClass, theme.accentColor)} />;
     }
   };
 
@@ -304,7 +279,7 @@ function LessonCard({ lesson, status, onClick }: LessonCardProps) {
           <span className={cn("text-xs opacity-60", theme.textColor)}>
             {lesson.objectives.length} つの学習目標
           </span>
-          <ChevronRight className={cn("w-4 h-4 opacity-60", theme.textColor)} />
+          <IoChevronForward className={cn("w-4 h-4 opacity-60", theme.textColor)} />
         </div>
       </div>
     </div>

--- a/src/components/code-editor/CodeEditor.tsx
+++ b/src/components/code-editor/CodeEditor.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from 'react';
 import dynamic from 'next/dynamic';
-import { RotateCcw } from 'lucide-react';
+import { IoRefresh } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
@@ -50,7 +50,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           className="flex items-center gap-1 px-3 py-1 text-sm text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-300"
           title="コードをリセット"
         >
-          <RotateCcw className="w-4 h-4" />
+          <IoRefresh className="w-4 h-4" />
           リセット
         </button>
       </div>

--- a/src/components/console-panel/ConsolePanel.tsx
+++ b/src/components/console-panel/ConsolePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Play, Trash2, Square } from 'lucide-react';
+import { IoPlay, IoTrash, IoStop } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 import { ConsoleOutput } from '@/types/lesson';
 
@@ -39,7 +39,7 @@ export const ConsolePanel: React.FC<ConsolePanelProps> = ({
             )}
             title="出力をクリア"
           >
-            <Trash2 className="w-4 h-4" />
+            <IoTrash className="w-4 h-4" />
             クリア
           </button>
           {isRunning && onCancel ? (
@@ -47,7 +47,7 @@ export const ConsolePanel: React.FC<ConsolePanelProps> = ({
               onClick={onCancel}
               className="flex items-center gap-1 px-4 py-1 text-sm font-medium rounded-lg transition-all duration-300 bg-red-500/80 text-white hover:bg-red-500"
             >
-              <Square className="w-4 h-4" />
+              <IoStop className="w-4 h-4" />
               停止
             </button>
           ) : (
@@ -62,7 +62,7 @@ export const ConsolePanel: React.FC<ConsolePanelProps> = ({
               )}
               title="コードを実行"
             >
-              <Play className="w-4 h-4" />
+              <IoPlay className="w-4 h-4" />
               実行
             </button>
           )}

--- a/src/components/lesson-panel/LessonPanel.tsx
+++ b/src/components/lesson-panel/LessonPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ChevronDown, ChevronUp, CheckCircle2, HelpCircle, AlertCircle, Info, AlertTriangle } from 'lucide-react';
+import { IoChevronDown, IoChevronUp, IoCheckmarkCircle, IoHelpCircle, IoAlertCircle, IoInformationCircle, IoWarning } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 import { Lesson, ValidationResult } from '@/types/lesson';
 
@@ -75,9 +75,9 @@ export const LessonPanel: React.FC<LessonPanelProps> = ({
             {/* Feedback Messages */}
             <div className="space-y-2">
               {validationResult.feedback.map((feedback, index) => {
-                const Icon = feedback.type === 'success' ? CheckCircle2 :
-                           feedback.type === 'error' ? AlertCircle :
-                           feedback.type === 'warning' ? AlertTriangle : Info;
+                const Icon = feedback.type === 'success' ? IoCheckmarkCircle :
+                           feedback.type === 'error' ? IoAlertCircle :
+                           feedback.type === 'warning' ? IoWarning : IoInformationCircle;
                 return (
                   <div
                     key={index}
@@ -104,12 +104,12 @@ export const LessonPanel: React.FC<LessonPanelProps> = ({
             onClick={() => setShowHints(!showHints)}
             className="flex items-center gap-2 text-lg font-semibold hover:text-gray-200 transition-colors"
           >
-            <HelpCircle className="w-5 h-5" />
+            <IoHelpCircle className="w-5 h-5" />
             ヒント
             {showHints ? (
-              <ChevronUp className="w-4 h-4" />
+              <IoChevronUp className="w-4 h-4" />
             ) : (
-              <ChevronDown className="w-4 h-4" />
+              <IoChevronDown className="w-4 h-4" />
             )}
           </button>
 
@@ -149,7 +149,7 @@ export const LessonPanel: React.FC<LessonPanelProps> = ({
             'flex items-center justify-center gap-2'
           )}
         >
-          <CheckCircle2 className="w-5 h-5" />
+          <IoCheckmarkCircle className="w-5 h-5" />
           答え合わせ
         </button>
       </div>

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 
 interface NavigationProps {
@@ -42,7 +42,7 @@ export const Navigation: React.FC<NavigationProps> = ({
               : 'opacity-40 cursor-not-allowed'
           )}
         >
-          <ChevronLeft className="w-5 h-5" />
+          <IoChevronBack className="w-5 h-5" />
           前のレッスン
         </button>
 
@@ -80,7 +80,7 @@ export const Navigation: React.FC<NavigationProps> = ({
           )}
         >
           次のレッスン
-          <ChevronRight className="w-5 h-5" />
+          <IoChevronForward className="w-5 h-5" />
         </button>
       </div>
     </div>

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { X, CheckCircle, AlertCircle, Info } from 'lucide-react';
+import { IoClose, IoCheckmarkCircle, IoAlertCircle, IoInformationCircle } from 'react-icons/io5';
 import { cn } from '@/lib/utils';
 
 export type ToastType = 'success' | 'error' | 'info';
@@ -20,17 +20,17 @@ interface ToastProps {
 
 const toastConfig = {
   success: {
-    icon: CheckCircle,
+    icon: IoCheckmarkCircle,
     className: 'glass-light border-green-200/30',
     iconClassName: 'text-green-400',
   },
   error: {
-    icon: AlertCircle,
+    icon: IoAlertCircle,
     className: 'glass-light border-red-200/30',
     iconClassName: 'text-red-400',
   },
   info: {
-    icon: Info,
+    icon: IoInformationCircle,
     className: 'glass-light border-blue-200/30',
     iconClassName: 'text-blue-400',
   },
@@ -70,7 +70,7 @@ export const Toast: React.FC<ToastProps> = ({ toast, onRemove }) => {
         )}
         aria-label="閉じる"
       >
-        <X className="w-4 h-4" />
+        <IoClose className="w-4 h-4" />
       </button>
     </div>
   );

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -120,8 +120,6 @@ export function getDifficultyBadgeClasses(difficulty: 'beginner' | 'intermediate
 }
 
 export function getProgressBarClasses(category: CategoryTheme): string {
-  const theme = getCategoryTheme(category);
-  
   switch (category) {
     case 'basic':
       return 'bg-teal-500';


### PR DESCRIPTION
## Summary
• lucide-reactからreact-iconsへの移行
• 全コンポーネントでIonicons (io5)セットに統一
• Bundle sizeの最適化とESLintエラー修正

## 変更内容

### 📦 パッケージ変更
- ❌ `lucide-react` を削除
- ✅ `react-icons` を追加（軽量で豊富なアイコンセット）

### 🔄 アイコン置き換え一覧
| 旧アイコン（lucide） | 新アイコン（react-icons） | 用途 |
|---------------------|------------------------|------|
| `ChevronDown/Up` | `IoChevronDown/Up` | ヒント展開 |
| `CheckCircle2` | `IoCheckmarkCircle` | 成功・完了表示 |
| `AlertCircle` | `IoAlertCircle` | エラー表示 |
| `Info` | `IoInformationCircle` | 情報表示 |
| `AlertTriangle` | `IoWarning` | 警告表示 |
| `ArrowLeft` | `IoArrowBack` | 戻るボタン |
| `ChevronRight` | `IoChevronForward` | 進むボタン |
| `Clock` | `IoTime` | 進行中ステータス |
| `Play` | `IoPlay` | 実行・再生 |
| `Trash2` | `IoTrash` | 削除・クリア |
| `Square` | `IoStop` | 停止 |
| `RotateCcw` | `IoRefresh` | リセット |
| `X` | `IoClose` | 閉じる |

### 🎯 影響を受けたコンポーネント
- `LessonPanel` - ヒント展開、答え合わせ、フィードバック表示
- `Toast` - 通知アイコン（成功/エラー/情報/閉じる）
- `Navigation` - 前へ/次へボタン
- `ConsolePanel` - 実行/停止/クリアボタン
- `CodeEditor` - リセットボタン
- `LessonSelectionPage` - ステータス表示、ナビゲーション
- `IndividualLessonPage` - 戻るボタン

## 技術的改善

### ✅ Bundle Size最適化
- より軽量なアイコンライブラリに変更
- Tree-shakingによる未使用アイコンの除外

### ✅ コード品質向上
- ESLintエラーの解消
- 未使用インポートの削除
- TypeScriptエラーの修正

### ✅ 一貫性の向上
- 全アイコンをIoniconsに統一
- 視覚的な一貫性の確保

## Test plan
- [x] 全ページでアイコンが正常に表示される
- [x] ビルドエラーなしでコンパイル成功
- [x] ESLintエラーなし
- [x] TypeScriptエラーなし
- [x] 機能的な変更なし（見た目のみの変更）

🤖 Generated with [Claude Code](https://claude.ai/code)